### PR TITLE
Python 3.6 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 - 2.7
 - 3.4
 - 3.5
+- 3.6
 
 sudo: false
 

--- a/lib/wordfilter/wordfilter.py
+++ b/lib/wordfilter/wordfilter.py
@@ -26,7 +26,7 @@ class Wordfilter(object):
 
         else:
             data = resource_string('wordfilter', '../badwords.json').decode('utf-8')
-            self.blacklist = [s.lower() for s in json.loads(data, 'r')]
+            self.blacklist = [s.lower() for s in json.loads(data)]
 
     def blacklisted(self, string):
         string = string.lower()


### PR DESCRIPTION
And fix a bug:

Was: `json.load(open(datafile, 'r'))`
Then: `[s.lower() for s in json.loads(data, 'r')]`

That `'r'` was accidentally carried over from an `open()` to the `json.loads()` in fitnr@d5b2864.

Only showed up in Python 3.6 because of a change in `json.loads`' parameters.

https://docs.python.org/3.6/library/json.html#json.loads